### PR TITLE
refactor(access-control): remove release manager role from user settings

### DIFF
--- a/src/packages/portal/pages/PortalPage/BaseVersionPage/PackageSettingsPage/AccessControlTab/AcUserRow.ts
+++ b/src/packages/portal/pages/PortalPage/BaseVersionPage/PackageSettingsPage/AccessControlTab/AcUserRow.ts
@@ -8,7 +8,6 @@ export class AcUserRow extends TableRow {
   readonly userCell = new TableCell(this.mainLocator.getByTestId('Cell-user'), this.componentName, 'name cell')
   readonly adminChx = new Checkbox(this.mainLocator.getByTestId('Cell-admin').getByRole('checkbox'), this.componentName, 'admin checkbox')
   readonly ownerChx = new Checkbox(this.mainLocator.getByTestId('Cell-owner').getByRole('checkbox'), this.componentName, 'owner checkbox')
-  readonly releaseManagerChx = new Checkbox(this.mainLocator.getByTestId('Cell-release-manager').getByRole('checkbox'), this.componentName, 'release manager checkbox')
   readonly editorChx = new Checkbox(this.mainLocator.getByTestId('Cell-editor').getByRole('checkbox'), this.componentName, 'editor checkbox')
   readonly viewerChx = new Checkbox(this.mainLocator.getByTestId('Cell-viewer').getByRole('checkbox'), this.componentName, 'viewer checkbox')
   readonly deleteBtn = new Button(this.mainLocator.getByTestId('DeleteButton'), this.componentName, 'delete button')

--- a/src/tests/portal/03-access-control/3.0-general.spec.ts
+++ b/src/tests/portal/03-access-control/3.0-general.spec.ts
@@ -41,7 +41,6 @@ test.describe('03.0 Access Control. General.', () => {
 
         await expect(accessControlTab.getUserRow(TEST_USER_1.name).adminChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_1.name).ownerChx).not.toBeChecked()
-        await expect(accessControlTab.getUserRow(TEST_USER_1.name).releaseManagerChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_1.name).editorChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_1.name).viewerChx).toBeChecked()
       })
@@ -53,7 +52,6 @@ test.describe('03.0 Access Control. General.', () => {
 
         await expect(accessControlTab.getUserRow(TEST_USER_2.name).adminChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_2.name).ownerChx).not.toBeChecked()
-        await expect(accessControlTab.getUserRow(TEST_USER_2.name).releaseManagerChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_2.name).editorChx).toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_2.name).viewerChx).not.toBeChecked()
       })
@@ -65,7 +63,6 @@ test.describe('03.0 Access Control. General.', () => {
 
         await expect(accessControlTab.getUserRow(TEST_USER_3.name).adminChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_3.name).ownerChx).toBeChecked()
-        await expect(accessControlTab.getUserRow(TEST_USER_3.name).releaseManagerChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_3.name).editorChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_3.name).viewerChx).not.toBeChecked()
       })
@@ -77,7 +74,6 @@ test.describe('03.0 Access Control. General.', () => {
 
         await expect(accessControlTab.getUserRow(TEST_USER_4.name).adminChx).toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_4.name).ownerChx).not.toBeChecked()
-        await expect(accessControlTab.getUserRow(TEST_USER_4.name).releaseManagerChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_4.name).editorChx).not.toBeChecked()
         await expect(accessControlTab.getUserRow(TEST_USER_4.name).viewerChx).not.toBeChecked()
       })
@@ -183,22 +179,22 @@ test.describe('03.0 Access Control. General.', () => {
 
       await portalPage.gotoPackage(PKG_P_UAC_G_MULT1_N, SETTINGS_TAB_USERS)
 
-      await test.step('Add "Release Manager" role by checkbox clicking', async () => {
-        await accessControlTab.getUserRow(testUserName).releaseManagerChx.click()
+      await test.step('Add "Editor" role by checkbox clicking', async () => {
+        await accessControlTab.getUserRow(testUserName).editorChx.click()
 
-        await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).toBeChecked()
+        await expect(accessControlTab.getUserRow(testUserName).editorChx).toBeChecked()
       })
 
-      await test.step('Remove "Release Manager" role by checkbox clicking', async () => {
-        await accessControlTab.getUserRow(testUserName).releaseManagerChx.click()
+      await test.step('Remove "Editor" role by checkbox clicking', async () => {
+        await accessControlTab.getUserRow(testUserName).editorChx.click()
 
-        await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).not.toBeChecked()
+        await expect(accessControlTab.getUserRow(testUserName).editorChx).not.toBeChecked()
       })
 
       await test.step('Undo changes', async () => {
         await portalPage.snackbar.undoBtn.click()
 
-        await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).toBeChecked()
+        await expect(accessControlTab.getUserRow(testUserName).editorChx).toBeChecked()
       })
     })
 
@@ -219,7 +215,6 @@ test.describe('03.0 Access Control. General.', () => {
 
       await expect(accessControlTab.getUserRow(testUserName).adminChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).ownerChx).not.toBeChecked()
-      await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).editorChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).viewerChx).toBeChecked()
     })
@@ -243,7 +238,6 @@ test.describe('03.0 Access Control. General.', () => {
 
       await expect(accessControlTab.getUserRow(testUserName).adminChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).ownerChx).not.toBeChecked()
-      await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).editorChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).viewerChx).toBeChecked()
     })
@@ -267,7 +261,6 @@ test.describe('03.0 Access Control. General.', () => {
 
       await expect(accessControlTab.getUserRow(testUserName).adminChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).ownerChx).not.toBeChecked()
-      await expect(accessControlTab.getUserRow(testUserName).releaseManagerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).editorChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUserName).viewerChx).not.toBeChecked()
     })
@@ -292,12 +285,10 @@ test.describe('03.0 Access Control. General.', () => {
 
       await expect(accessControlTab.getUserRow(testUser2Name).adminChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUser2Name).ownerChx).not.toBeChecked()
-      await expect(accessControlTab.getUserRow(testUser2Name).releaseManagerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUser2Name).editorChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUser2Name).viewerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUser3Name).adminChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUser3Name).ownerChx).not.toBeChecked()
-      await expect(accessControlTab.getUserRow(testUser3Name).releaseManagerChx).not.toBeChecked()
       await expect(accessControlTab.getUserRow(testUser3Name).editorChx).toBeChecked()
       await expect(accessControlTab.getUserRow(testUser3Name).viewerChx).not.toBeChecked()
     })


### PR DESCRIPTION
The release manager role is no longer needed in the access control settings. This commit removes the related checkbox and updates the corresponding tests to reflect the change.