### PR TITLE
test: add flaky test annotations for outdated notification tests

### DIFF
--- a/src/test-setup/annotations.ts
+++ b/src/test-setup/annotations.ts
@@ -1,0 +1,1 @@
+export const OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION = 'Sometimes the Outdated Revision notification dialog doesn\'t appear immediately when switching tabs, although by design it should appear instantly upon tab switching'

--- a/src/test-setup/index.ts
+++ b/src/test-setup/index.ts
@@ -1,3 +1,4 @@
+export * from './annotations'
 export * from './process'
 export * from './timeouts'
 export * from './urls'

--- a/src/tests/portal/13-revisions/13.1.1.2-package-revisions-notification.spec.ts
+++ b/src/tests/portal/13-revisions/13.1.1.2-package-revisions-notification.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@fixtures'
 import { expect } from '@services/expect-decorator'
 import { PortalPage } from '@portal/pages/PortalPage'
-import { SHORT_EXPECT, SHORT_TIMEOUT, TICKET_BASE_URL } from '@test-setup'
+import { OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION, SHORT_EXPECT, SHORT_TIMEOUT, TICKET_BASE_URL } from '@test-setup'
 import { VERSION_OPERATIONS_TAB_REST } from '@portal/entities'
 import { PK_REV_VAR, V_P_PKG_REV_1_N } from '@test-data/portal'
 
@@ -16,8 +16,11 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test('[P-COPR-3.1] Outdated revision notification on the "Operations" tab',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -60,9 +63,12 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test.skip('[P-COPR-3.2] Outdated revision notification on the "API Changes" tab',
     {
+      tag: ['@flaky'],
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-977` }],
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-977` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -105,9 +111,12 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test.skip('[P-COPR-3.3] Outdated revision notification on the "Deprecated" tab',
     {
+      tag: ['@flaky'],
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-976` }],
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-976` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -150,7 +159,11 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test('[P-COPR-3.4] Outdated revision notification on the "Documents" tab',
     {
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+      tag: ['@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -193,7 +206,11 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test('[P-COPR-3.5] Outdated revision notification on the "Overview" tab',
     {
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+      tag: ['@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -246,8 +263,11 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test('[P-COPR-3.6] Outdated revision notification on the "Settings" page',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -272,8 +292,11 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
 
   test('[P-COPR-3.7] Outdated revision notification on the "Comparison" page',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8412` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 

--- a/src/tests/portal/13-revisions/13.1.2.2-dashboard-revisions-notification.spec.ts
+++ b/src/tests/portal/13-revisions/13.1.2.2-dashboard-revisions-notification.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@fixtures'
 import { expect } from '@services/expect-decorator'
 import { PortalPage } from '@portal/pages/PortalPage'
-import { SHORT_EXPECT, SHORT_TIMEOUT, TICKET_BASE_URL } from '@test-setup'
+import { OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION, SHORT_EXPECT, SHORT_TIMEOUT, TICKET_BASE_URL } from '@test-setup'
 import { VERSION_OPERATIONS_TAB_REST } from '@portal/entities'
 import { D_REV_VAR, V_P_DSH_REV_1_N } from '@test-data/portal'
 
@@ -12,8 +12,11 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test('[P-CODR-3.1] Outdated revision notification on the "Operations" tab',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -56,9 +59,12 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test.skip('[P-CODR-3.2] Outdated revision notification on the "API Changes" tab',
     {
+      tag: ['@flaky'],
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-977` }],
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-977` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -101,9 +107,12 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test.skip('[P-CODR-3.3] Outdated revision notification on the "Deprecated" tab',
     {
+      tag: ['@flaky'],
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-976` }],
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-976` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -146,7 +155,11 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test('[P-CODR-3.4] Outdated revision notification on the "Documents" tab',
     {
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+      tag: ['@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -189,7 +202,11 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test('[P-CODR-3.5] Outdated revision notification on the "Overview" tab',
     {
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+      tag: ['@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -242,8 +259,11 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test('[P-CODR-3.6] Outdated revision notification on the "Settings" page',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 
@@ -268,8 +288,11 @@ test.describe('13.1.2.2 Dashboard revisions (Outdated revision notification)', (
 
   test('[P-CODR-3.7] Outdated revision notification on the "Comparison" page',
     {
-      tag: '@smoke',
-      annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+      tag: ['@smoke', '@flaky'],
+      annotation: [
+        { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8423` },
+        { type: 'Flaky', description: OUTDATED_NOTIFICATION_FLAKY_TEST_ANNOTATION },
+      ],
     },
     async ({ sysadminPage: page, apihubTDM }) => {
 


### PR DESCRIPTION
The Outdated Revision notification dialog sometimes doesn't appear immediately when switching tabs, which is a known flaky behavior. This commit adds annotations to mark the affected tests as flaky, ensuring better tracking and awareness of the issue.