### PR TITLE
test: revision of disabled tests

### DIFF
--- a/src/tests/portal/04-entity-actions/4.3.2-package-editing-publishing.spec.ts
+++ b/src/tests/portal/04-entity-actions/4.3.2-package-editing-publishing.spec.ts
@@ -76,7 +76,7 @@ test.describe('4.3.2 Package publishing via Portal', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8915` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-A-10451` },
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1226` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -116,7 +116,7 @@ test.describe('4.3.2 Package publishing via Portal', () => {
         await versionPage.toolbar.settingsBtn.click()
         await packageSettingsPage.versionsTab.click()
 
-        //! await expect(packageSettingsPage.versionsTab.getVersionRow('publish-draft')).toBeVisible() //Issue TestCase-A-10451
+        //! await expect(packageSettingsPage.versionsTab.getVersionRow('publish-draft')).toBeVisible() //Issue TestCase-B-1226
       })
     })
 

--- a/src/tests/portal/04-entity-actions/4.3.3-package-publish-pattern.spec.ts
+++ b/src/tests/portal/04-entity-actions/4.3.3-package-publish-pattern.spec.ts
@@ -52,7 +52,7 @@ test.describe('4.3.3 Package publishing via Portal (Negative)', () => {
       })
     })
 
-  test('[P-PVC-3] Publish draft version that does not match the new pattern and the global pattern',
+  test('[P-PVC-3-N] Publish draft version that does not match the new pattern and the global pattern',
     {
       annotation: { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8923` },
     },

--- a/src/tests/portal/04-entity-actions/4.4.2-dashboard-editing-publishing.spec.ts
+++ b/src/tests/portal/04-entity-actions/4.4.2-dashboard-editing-publishing.spec.ts
@@ -26,7 +26,7 @@ test.describe('4.4.2 Dashboard editing/publishing', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-4496` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-A-10451` },
+        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1226` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -67,7 +67,7 @@ test.describe('4.4.2 Dashboard editing/publishing', () => {
         await versionPage.toolbar.settingsBtn.click()
         await packageSettingsPage.versionsTab.click()
 
-        //! await expect(packageSettingsPage.versionsTab.getVersionRow('publish-draft')).toBeVisible() //Issue TestCase-A-10451
+        //! await expect(packageSettingsPage.versionsTab.getVersionRow('publish-draft')).toBeVisible() //Issue TestCase-B-1226
       })
     })
 

--- a/src/tests/portal/05-view-details/5.3-dashboard-details.spec.ts
+++ b/src/tests/portal/05-view-details/5.3-dashboard-details.spec.ts
@@ -63,7 +63,7 @@ test.describe('5.3 Dashboard details', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-5895` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1023` }],
+      ],
     },
     async ({ sysadminPage: page }) => {
 
@@ -88,7 +88,7 @@ test.describe('5.3 Dashboard details', () => {
       await expect.soft(overviewTab.packagesTab.getExcludedPackageRow(PK11).statusCell).toHaveText(V_P_PKG_OPERATIONS_REST_R.status)
       await expect.soft(overviewTab.packagesTab.getPackageRow(PK12).versionCell).toHaveText(V_P_PKG_FOR_DASHBOARDS_REST_BASE_R.version)
       await expect.soft(overviewTab.packagesTab.getPackageRow(PK12).statusCell).toHaveText(V_P_PKG_FOR_DASHBOARDS_REST_BASE_R.status)
-      // await expect.soft(overviewTab.packagesTab.getReferenceRow(PK13).versionCell).toHaveText(PKG_FOR_DASHBOARDS_DELETED_TEST_VERSION.version) // TODO TestCase-B-1023
+      await expect.soft(overviewTab.packagesTab.getPackageRow(PK13).versionCell).toHaveText(V_P_PKG_FOR_DASHBOARDS_DELETED_R.version)
       await expect.soft(overviewTab.packagesTab.getPackageRow(PK13).statusCell).toHaveText(V_P_PKG_FOR_DASHBOARDS_DELETED_R.status)
       await expect.soft(overviewTab.packagesTab.getPackageRow(PK13).packageCell.notExistAlertIcon).toBeVisible()
     })

--- a/src/tests/portal/09-comparison/9.2-compare-operations-package.spec.ts
+++ b/src/tests/portal/09-comparison/9.2-compare-operations-package.spec.ts
@@ -209,7 +209,6 @@ test.describe('09.2 Compare Operations (Package)', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-1734` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1447` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -233,7 +232,7 @@ test.describe('09.2 Compare Operations (Package)', () => {
       await compareOperationsPage.sidebar.filtersBtn.click()
       await compareOperationsPage.sidebar.documentFilterAc.click()
 
-      //! await expect(compareOperationsPage.sidebar.documentFilterAc.getListItem()).toHaveCount(2) //Issue TestCase-B-1447
+      await expect(compareOperationsPage.sidebar.documentFilterAc.getListItem()).toHaveCount(3) // Documents without changes are allowed in the filter
       await expect(compareOperationsPage.sidebar.documentFilterAc.getListItem(docTitle1)).toBeVisible()
       await expect(compareOperationsPage.sidebar.documentFilterAc.getListItem(docTitle2)).toBeVisible()
 

--- a/src/tests/portal/12-grouping/12.1.1-pkg-man-grouping-crud.spec.ts
+++ b/src/tests/portal/12-grouping/12.1.1-pkg-man-grouping-crud.spec.ts
@@ -228,7 +228,6 @@ test.describe('12.1.1 Manual grouping: CRUD (Packages)', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-10190` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1390` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -243,11 +242,11 @@ test.describe('12.1.1 Manual grouping: CRUD (Packages)', () => {
       await portalPage.gotoVersion(testVersion, VERSION_OVERVIEW_TAB_GROUPS)
       await groupsTab.getGroupRow(groupName).openEditGroupParametersDialog()
 
-      /*!await updateDialog.fillForm({ template: testMeta!.templateYaml }) //Issue TestCase-B-1390
+      await updateDialog.fillForm({ template: testMeta!.templateYaml })
 
       await expect(updateDialog.notDownloadableFilePreview).toBeVisible()
 
-      await updateDialog.notDownloadableFilePreview.deleteBtn.click()*/
+      await updateDialog.notDownloadableFilePreview.deleteBtn.click()
 
       await expect(updateDialog.browseBtn).toBeEnabled()
 

--- a/src/tests/portal/12-grouping/12.1.4-pkg-prefix-grouping-crud.spec.ts
+++ b/src/tests/portal/12-grouping/12.1.4-pkg-prefix-grouping-crud.spec.ts
@@ -217,7 +217,6 @@ test.describe('12.1.4 Prefix grouping: CRUD', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-10181` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1390` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -233,11 +232,11 @@ test.describe('12.1.4 Prefix grouping: CRUD', () => {
       await portalPage.gotoVersion(testVersion, VERSION_OVERVIEW_TAB_GROUPS)
       await groupsTab.getGroupRow(groupName).openEditGroupParametersDialog()
 
-      /*!await updateDialog.fillForm({ template: testMeta!.templateYaml }) //Issue TestCase-B-1390
+      await updateDialog.fillForm({ template: testMeta!.templateYaml })
 
       await expect(updateDialog.notDownloadableFilePreview).toBeVisible()
 
-      await updateDialog.notDownloadableFilePreview.deleteBtn.click()*/
+      await updateDialog.notDownloadableFilePreview.deleteBtn.click()
 
       await expect(updateDialog.browseBtn).toBeEnabled()
 

--- a/src/tests/portal/12-grouping/12.2.1-dsh-man-grouping-crud.spec.ts
+++ b/src/tests/portal/12-grouping/12.2.1-dsh-man-grouping-crud.spec.ts
@@ -232,7 +232,6 @@ test.describe('12.2.1 Manual grouping: CRUD (Dashboards)', () => {
       tag: '@smoke',
       annotation: [
         { type: 'Test Case', description: `${TICKET_BASE_URL}TestCase-A-8350` },
-        { type: 'Issue', description: `${TICKET_BASE_URL}TestCase-B-1390` },
       ],
     },
     async ({ sysadminPage: page }) => {
@@ -247,11 +246,11 @@ test.describe('12.2.1 Manual grouping: CRUD (Dashboards)', () => {
       await portalPage.gotoVersion(testVersion, VERSION_OVERVIEW_TAB_GROUPS)
       await groupsTab.getGroupRow(groupName).openEditGroupParametersDialog()
 
-      /*!await updateDialog.fillForm({ template: testMeta!.templateYaml }) //Issue TestCase-B-1390
+      await updateDialog.fillForm({ template: testMeta!.templateYaml })
 
       await expect(updateDialog.notDownloadableFilePreview).toBeVisible()
 
-      await updateDialog.notDownloadableFilePreview.deleteBtn.click()*/
+      await updateDialog.notDownloadableFilePreview.deleteBtn.click()
 
       await expect(updateDialog.browseBtn).toBeEnabled()
 

--- a/src/tests/portal/13-revisions/13.1.1.2-package-revisions-notification.spec.ts
+++ b/src/tests/portal/13-revisions/13.1.1.2-package-revisions-notification.spec.ts
@@ -10,10 +10,6 @@ test.describe('13.1.1.2 Package revisions (Outdated revision notification)', () 
   const testPackage = PK_REV_VAR
   const testVersion = V_P_PKG_REV_1_N
 
-  test.beforeAll(async () => {
-
-  })
-
   test('[P-COPR-3.1] Outdated revision notification on the "Operations" tab',
     {
       tag: ['@smoke', '@flaky'],


### PR DESCRIPTION
- Enable notDownloadableFilePreview (TestCase-B-1390)
- Enable revision for deleted package (TestCase-B-1023)
- Update ticket number of version tab after publish  (TestCase-B-1226)
- Fix test ID for better traceability
- Remove redundant beforeAll for improved test efficiency
- Allow documents without changes in the filter