### PR TITLE
refactor(copy-dialog): extract field validation logic into a separate test

### DIFF
--- a/src/packages/shared/components/base/text-fields/Autocomplete.ts
+++ b/src/packages/shared/components/base/text-fields/Autocomplete.ts
@@ -26,9 +26,9 @@ export class Autocomplete extends TextField {
 
   getChip(chipName?: string): Chip {
     if (chipName) {
-      return new Chip(this.page.locator('.MuiChip-root').filter({ hasText: chipName }).first(), chipName)
+      return new Chip(this.rootLocator.locator('.MuiChip-root').filter({ hasText: new RegExp(`^${chipName}$`) }), chipName)
     }
-    return new Chip(this.page.locator('.MuiChip-root'))
+    return new Chip(this.rootLocator.locator('.MuiChip-root'))
   }
 
   async set(listItem: string | string[], options?: { clearBefore?: boolean; fillItemName?: boolean }): Promise<void> {

--- a/src/test-data/portal/copying/versions.ts
+++ b/src/test-data/portal/copying/versions.ts
@@ -26,9 +26,11 @@ export const V_P_DSH_COPYING_SOURCE_R: Version = {
   ...V_P_DSH_CHANGELOG_REST_CHANGED_R,
   pkg: P_DSH_CP_SOURCE,
   previousVersion: '',
+  metadata: { versionLabels: ['source-label-1', 'source-label-2'] },
 } as const
 export const V_P_DSH_COPYING_RELEASE_N: Version = {
   ...V_P_DSH_CHANGELOG_REST_BASE_R,
   pkg: P_DSH_CP_RELEASE,
   version: '2000.1',
+  metadata: { versionLabels: ['release-label-1', 'release-label-2'] },
 } as const


### PR DESCRIPTION
- Split P-CPAP-1/P-CDAD-1 tests into P-CPAP-1.1/P-CDAD-1.1 (dedicated field validation logic) and P-CPAP-1.2/P-CDAD-1.2 (empty package copying)
- Improve locator usage in an Autocomplete component with more precise RegExp matching
- Add detailed test descriptions for all test cases
- Fix chip selection in test assertions
- Replace commented code with proper assertions
- Update revision validation to be more robust against test retries
- Change source version constant for better test data organization