### PR TITLE
test: temporarily remove check of FE version in the System Information pop-up

### DIFF
--- a/src/test-data/props/sys-info.ts
+++ b/src/test-data/props/sys-info.ts
@@ -13,13 +13,8 @@ export async function getSysInfo(): Promise<SysInfo> {
     throw Error(await getRestFailMsg('Getting System Information', response))
   }
 
-  const buildInfo: {
-    backendVersion: string
-    frontendVersion: string
-    productionMode: boolean
-  } = {
+  const buildInfo: BuildInfo = {
     backendVersion: jsonBody.backendVersion,
-    frontendVersion: (jsonBody.frontendVersion).replace('\n', ''),
     productionMode: jsonBody.productionMode,
   }
 
@@ -31,9 +26,10 @@ export async function getSysInfo(): Promise<SysInfo> {
 
 interface SysInfo {
   environment: string
-  build: {
-    backendVersion: string
-    frontendVersion: string
-    productionMode: boolean
-  }
+  build: BuildInfo
+}
+
+interface BuildInfo {
+  backendVersion: string
+  productionMode: boolean
 }

--- a/src/tests/portal/01-general/1.2-general.spec.ts
+++ b/src/tests/portal/01-general/1.2-general.spec.ts
@@ -66,7 +66,7 @@ test.describe('General', () => {
       await expect.soft(sysInfoPopup.content).toBeVisible()
       await expect.soft(sysInfoPopup.closeBtn).toBeVisible()
       await expect.soft(sysInfoPopup.content).toContainText(build.backendVersion)
-      await expect.soft(sysInfoPopup.content).toContainText(build.frontendVersion)
+      // TODO: add FE version check for non empty value
       // TODO: Add checking api/v1/system/info "externalLinks": []
     })
 


### PR DESCRIPTION
Due to changes in https://github.com/Netcracker/qubership-apihub-backend/issues/110