### PR TITLE
test: set a specific default releaseVersionPattern for tested entities

### DIFF
--- a/src/test-data/portal/dashboards.ts
+++ b/src/test-data/portal/dashboards.ts
@@ -2,6 +2,7 @@ import { DASHBOARD_PREFIX } from '@test-data'
 import { Dashboard } from '@test-data/props'
 import { G_REV_IMM, G_REV_VAR, P_GR_CRUD, VAR_GR } from './groups'
 import { P_WS_MAIN_R } from './workspaces'
+import { RV_PATTERN_DEF } from '@test-data/portal/other'
 
 export const D11 = new Dashboard({
   name: `${DASHBOARD_PREFIX}-11`,
@@ -50,6 +51,7 @@ export const P_DSH_UPDATE = new Dashboard({
   alias: 'DUPDT',
   parent: P_GR_CRUD,
   description: 'For update',
+  releaseVersionPattern: RV_PATTERN_DEF,
   testMeta: {
     updatedName: 'Updated',
     updatedServiceName: `dash-crud-${process.env.TEST_ID_N}`,

--- a/src/test-data/portal/packages.ts
+++ b/src/test-data/portal/packages.ts
@@ -1,16 +1,7 @@
 import { PACKAGE_PREFIX } from '@test-data'
 import { Package } from '@test-data/props'
-import {
-  G_PUBLISH_IMM,
-  G_PUBLISH_VAR,
-  G_REV_IMM,
-  G_REV_VAR,
-  G_SETTINGS_VAR,
-  IMM_GR,
-  P_GR_CRUD,
-  VAR_GR,
-} from './groups'
-import { RV_PATTERN_NEW } from './other'
+import { G_PUBLISH_IMM, G_PUBLISH_VAR, G_REV_IMM, G_REV_VAR, G_SETTINGS_VAR, IMM_GR, P_GR_CRUD, VAR_GR } from './groups'
+import { RV_PATTERN_DEF, RV_PATTERN_NEW } from './other'
 import { P_WS_MAIN_R } from './workspaces'
 
 export const PK11 = new Package({
@@ -60,6 +51,7 @@ export const PK_PUB_IMM_1 = new Package({
   name: 'Publish-reusable-1',
   alias: 'PKPUBIMM1',
   parent: G_PUBLISH_IMM,
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 export const PK_PUB_IMM_2 = new Package({
   name: 'Publish-reusable-2',

--- a/src/test-data/portal/uac/admin/dashboards.ts
+++ b/src/test-data/portal/uac/admin/dashboards.ts
@@ -1,6 +1,7 @@
 import { Dashboard } from '@test-data/props'
 import { GRP_P_ADMIN_CRUD_N, GRP_P_ADMIN_ROOT_N } from './groups'
 import { TOKEN_ADMIN_DASHBOARD } from './tokens'
+import { RV_PATTERN_DEF } from '@test-data/portal'
 
 export const DSH_P_ADMIN_N = new Dashboard({
   name: 'Admin',
@@ -14,6 +15,7 @@ export const DSH_P_ADMIN_EDITING_N = new Dashboard({
   alias: 'DADMINE',
   parent: GRP_P_ADMIN_CRUD_N,
   apiKeys: [TOKEN_ADMIN_DASHBOARD],
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const DSH_P_ADMIN_DELETING_N = new Dashboard({

--- a/src/test-data/portal/uac/admin/groups.ts
+++ b/src/test-data/portal/uac/admin/groups.ts
@@ -1,6 +1,7 @@
 import { Group } from '@test-data/props'
 import { GRP_P_UAC_N } from '../general/groups'
 import { TOKEN_ADMIN_GROUP } from './tokens'
+import { RV_PATTERN_DEF } from '@test-data/portal'
 
 export const GRP_P_ADMIN_ROOT_N = new Group({
   name: 'Admin',
@@ -26,6 +27,7 @@ export const GRP_P_ADMIN_EDITING_N = new Group({
   alias: 'GADMINE',
   parent: GRP_P_ADMIN_CRUD_N,
   apiKeys: [TOKEN_ADMIN_GROUP],
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const GRP_P_ADMIN_DELETING_N = new Group({

--- a/src/test-data/portal/uac/admin/packages.ts
+++ b/src/test-data/portal/uac/admin/packages.ts
@@ -1,7 +1,7 @@
 import { Package } from '@test-data/props'
 import { GRP_P_ADMIN_CRUD_N, GRP_P_ADMIN_ROOT_N } from './groups'
 import { TOKEN_ADMIN_PACKAGE } from './tokens'
-import { DEF_PREFIX_GROUP } from '@test-data/portal'
+import { DEF_PREFIX_GROUP, RV_PATTERN_DEF } from '@test-data/portal'
 
 export const PKG_P_ADMIN_N = new Package({
   name: 'Admin',
@@ -16,6 +16,7 @@ export const PKG_P_ADMIN_EDITING_N = new Package({
   alias: 'PADMINE',
   parent: GRP_P_ADMIN_CRUD_N,
   apiKeys: [TOKEN_ADMIN_PACKAGE],
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const PKG_P_ADMIN_DELETING_N = new Package({

--- a/src/test-data/portal/uac/owner/dashboards.ts
+++ b/src/test-data/portal/uac/owner/dashboards.ts
@@ -1,6 +1,7 @@
 import { Dashboard } from '@test-data/props'
 import { GRP_P_OWNER_CRUD_N, GRP_P_OWNER_ROOT_N } from './groups'
 import { TOKEN_OWNER_DASHBOARD } from './tokens'
+import { RV_PATTERN_DEF } from '@test-data/portal'
 
 export const DSH_P_OWNER_N = new Dashboard({
   name: 'Owner',
@@ -13,6 +14,7 @@ export const DSH_P_OWNER_EDITING_N = new Dashboard({
   name: 'Owner-editing',
   alias: 'DOWNERE',
   parent: GRP_P_OWNER_CRUD_N,
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const DSH_P_OWNER_DELETING_N = new Dashboard({

--- a/src/test-data/portal/uac/owner/groups.ts
+++ b/src/test-data/portal/uac/owner/groups.ts
@@ -1,6 +1,7 @@
 import { Group } from '@test-data/props'
 import { GRP_P_UAC_N } from '../general/groups'
 import { TOKEN_OWNER_GROUP } from './tokens'
+import { RV_PATTERN_DEF } from '@test-data/portal'
 
 export const GRP_P_OWNER_ROOT_N = new Group({
   name: 'Owner',
@@ -25,6 +26,7 @@ export const GRP_P_OWNER_EDITING_N = new Group({
   name: 'Owner-editing',
   alias: 'GOWNERE',
   parent: GRP_P_OWNER_CRUD_N,
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const GRP_P_OWNER_DELETING_N = new Group({

--- a/src/test-data/portal/uac/owner/packages.ts
+++ b/src/test-data/portal/uac/owner/packages.ts
@@ -1,7 +1,7 @@
 import { Package } from '@test-data/props'
 import { GRP_P_OWNER_CRUD_N, GRP_P_OWNER_ROOT_N } from './groups'
 import { TOKEN_OWNER_PACKAGE } from './tokens'
-import { DEF_PREFIX_GROUP } from '@test-data/portal'
+import { DEF_PREFIX_GROUP, RV_PATTERN_DEF } from '@test-data/portal'
 
 export const PKG_P_OWNER_N = new Package({
   name: 'Owner',
@@ -15,6 +15,7 @@ export const PKG_P_OWNER_EDITING_N = new Package({
   name: 'Owner-editing',
   alias: 'POWNERE',
   parent: GRP_P_OWNER_CRUD_N,
+  releaseVersionPattern: RV_PATTERN_DEF,
 }, { kindPrefix: true })
 
 export const PKG_P_OWNER_DELETING_N = new Package({

--- a/src/test-data/props/packages.ts
+++ b/src/test-data/props/packages.ts
@@ -1,11 +1,4 @@
-import type {
-  BasePackageParams,
-  GroupParams,
-  PackageKind,
-  PackageParams,
-  TestMetaBasePackage,
-  WorkspaceParams,
-} from './params'
+import type { BasePackageParams, GroupParams, PackageKind, PackageParams, TestMetaBasePackage, WorkspaceParams } from './params'
 import type { PackageApiKey } from '@shared/entities'
 import { TEST_PREFIX } from '@test-data'
 import process from 'node:process'
@@ -29,12 +22,14 @@ export class Workspace extends BasePackage {
   readonly packageId = this.alias
   readonly defaultRole?: string
   readonly apiKeys?: PackageApiKey[]
+  readonly releaseVersionPattern?: string
 
   constructor(params: WorkspaceParams, nameOptions?: NameOptions) {
     const _name = setName(params.name, 'WSP', nameOptions)
     super({ ...params, name: _name })
     this.defaultRole = params.defaultRole
     this.apiKeys = params.apiKeys
+    this.releaseVersionPattern = params.releaseVersionPattern
   }
 }
 
@@ -66,14 +61,12 @@ export class Group extends Workspace {
 export class Package extends Group {
   readonly kind: PackageKind = 'package'
   readonly serviceName?: string
-  readonly releaseVersionPattern?: string
   readonly restGroupingPrefix?: string
 
   constructor(params: PackageParams, nameOptions?: NameOptions) {
     const _name = setName(params.name, 'PKG', nameOptions)
     super({ ...params, name: _name })
     this.serviceName = params.serviceName
-    this.releaseVersionPattern = params.releaseVersionPattern
     this.restGroupingPrefix = params.restGroupingPrefix
   }
 

--- a/src/test-data/props/params.ts
+++ b/src/test-data/props/params.ts
@@ -20,6 +20,7 @@ export interface BasePackageParams {
 export interface WorkspaceParams extends BasePackageParams {
   readonly defaultRole?: string
   readonly apiKeys?: PackageApiKey[]
+  releaseVersionPattern?: string
 }
 
 export interface GroupParams extends WorkspaceParams {
@@ -28,7 +29,6 @@ export interface GroupParams extends WorkspaceParams {
 
 export interface PackageParams extends GroupParams {
   serviceName?: string
-  releaseVersionPattern?: string
   restGroupingPrefix?: string
 }
 


### PR DESCRIPTION
When creating test data for packages where a pattern is being tested, a custom pattern `^[0-9]{4}[.]{1}[1-4]{1}$` is set instead of the default `.*`