### PR TITLE
chore: bump dependencies (playwright 1.55.0) and fix errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # IDEs
-/.vscode/
 /.cursor/
-/.trae/
 /.junie/
+/.qoder/
+/.trae/
+/.vscode/
+/.windsurf/
+/.zed/
 /.idea/
 !/.idea/icon.png
 *.iml

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.36.1-dev.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@playwright/test": "1.53.2",
-        "@types/node": "22.16.0",
+        "@playwright/test": "1.55.0",
+        "@types/node": "22.18.1",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
-        "cross-env": "7.0.3",
-        "dotenv": "17.0.0",
+        "cross-env": "10.0.0",
+        "dotenv": "17.2.2",
         "eslint": "8.57.1",
         "eslint-plugin-filenames": "1.3.2",
         "eslint-plugin-json": "3.1.0",
@@ -23,8 +23,15 @@
         "eslint-plugin-sort-exports": "0.9.1",
         "eslint-plugin-ui-testing": "2.0.1",
         "jszip": "3.10.1",
-        "typescript": "5.8.3"
+        "typescript": "5.9.2"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -200,13 +207,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
-      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.53.2"
+        "playwright": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -222,9 +229,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.0.tgz",
-      "integrity": "sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -752,21 +759,21 @@
       "dev": true
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -831,9 +838,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
-      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1742,13 +1749,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
-      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.2"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1761,9 +1768,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2053,9 +2060,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "format": "npm run lint --fix"
   },
   "devDependencies": {
-    "@playwright/test": "1.53.2",
-    "@types/node": "22.16.0",
+    "@playwright/test": "1.55.0",
+    "@types/node": "22.18.1",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "@typescript-eslint/types": "7.18.0",
-    "cross-env": "7.0.3",
-    "dotenv": "17.0.0",
+    "cross-env": "10.0.0",
+    "dotenv": "17.2.2",
     "eslint": "8.57.1",
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-promise": "6.6.0",
@@ -27,7 +27,7 @@
     "eslint-plugin-filenames": "1.3.2",
     "eslint-plugin-ui-testing": "2.0.1",
     "jszip": "3.10.1",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   },
   "eslintConfig": {
     "extends": ".eslintrc.json"

--- a/resources/portal/atui_petstore20.json
+++ b/resources/portal/atui_petstore20.json
@@ -38,8 +38,7 @@
     }
   ],
   "schemes": [
-    "https",
-    "http"
+    "https"
   ],
   "paths": {
     "/pet": {
@@ -469,6 +468,10 @@
         "summary": "Place an order for a pet",
         "description": "",
         "operationId": "placeOrder",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -576,6 +579,10 @@
         "summary": "Create user",
         "description": "This can only be done by the logged in user.",
         "operationId": "createUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -606,6 +613,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithArrayInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -639,6 +650,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithListInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -780,6 +795,10 @@
         "summary": "Updated user",
         "description": "This can only be done by the logged in user.",
         "operationId": "updateUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -845,8 +864,9 @@
   "securityDefinitions": {
     "petstore_auth": {
       "type": "oauth2",
-      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-      "flow": "implicit",
+      "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+      "flow": "accessCode",
+      "tokenUrl": "https://petstore.swagger.io/oauth/token",
       "scopes": {
         "write:pets": "modify pets in your account",
         "read:pets": "read your pets"

--- a/resources/portal/for-changelog/atui_petstore20_changelog_base.json
+++ b/resources/portal/for-changelog/atui_petstore20_changelog_base.json
@@ -38,8 +38,7 @@
     }
   ],
   "schemes": [
-    "https",
-    "http"
+    "https"
   ],
   "paths": {
     "/pet": {
@@ -469,6 +468,10 @@
         "summary": "Place an order for a pet",
         "description": "",
         "operationId": "placeOrder",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -576,6 +579,10 @@
         "summary": "Create user",
         "description": "This can only be done by the logged in user.",
         "operationId": "createUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -606,6 +613,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithArrayInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -639,6 +650,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithListInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -780,6 +795,10 @@
         "summary": "Updated user",
         "description": "This can only be done by the logged in user.",
         "operationId": "updateUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -845,8 +864,9 @@
   "securityDefinitions": {
     "petstore_auth": {
       "type": "oauth2",
-      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-      "flow": "implicit",
+      "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+      "flow": "accessCode",
+      "tokenUrl": "https://petstore.swagger.io/oauth/token",
       "scopes": {
         "write:pets": "modify pets in your account",
         "read:pets": "read your pets"

--- a/resources/portal/for-changelog/atui_petstore20_changelog_changed.json
+++ b/resources/portal/for-changelog/atui_petstore20_changelog_changed.json
@@ -38,8 +38,7 @@
     }
   ],
   "schemes": [
-    "https",
-    "http"
+    "https"
   ],
   "paths": {
     "/pet": {
@@ -419,6 +418,10 @@
         "summary": "Place an order for a pet",
         "description": "",
         "operationId": "placeOrder",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -526,6 +529,10 @@
         "summary": "Create user",
         "description": "This can only be done by the logged in user.",
         "operationId": "createUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -556,6 +563,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithArrayInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -589,6 +600,10 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithListInput",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -730,6 +745,10 @@
         "summary": "Updated user",
         "description": "This can only be done by the logged in user.",
         "operationId": "updateUser",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -795,8 +814,9 @@
   "securityDefinitions": {
     "petstore_auth": {
       "type": "oauth2",
-      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-      "flow": "implicit",
+      "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+      "flow": "accessCode",
+      "tokenUrl": "https://petstore.swagger.io/oauth/token",
       "scopes": {
         "write:pets": "modify pets in your account",
         "read:pets": "read your pets"

--- a/src/packages/shared/entities/files.ts
+++ b/src/packages/shared/entities/files.ts
@@ -5,7 +5,6 @@ export const ROOT_RESOURCES = 'resources'
 export const ROOT_DOWNLOADS = 'temp/downloads'
 
 export class TestFile {
-
   readonly path: string
   readonly testMeta?: TestMetaFile
   name: string
@@ -21,7 +20,8 @@ export class TestFile {
   }
 
   async blob(): Promise<Blob> {
-    return new Blob([await readFile(this.path)])
+    const buffer = await readFile(this.path)
+    return new Blob([new Uint8Array(buffer)])
   }
 }
 

--- a/src/tests/portal/03-access-control/3.1.1-viewer-package.spec.ts
+++ b/src/tests/portal/03-access-control/3.1.1-viewer-package.spec.ts
@@ -196,7 +196,7 @@ test.describe('03.1.1 Access Control. Viewer role. (Package)', () => {
         versionsTab,
         accessTokensTab,
         accessControlTab,
-        noPermissionPlaceholder
+        noPermissionPlaceholder,
       } = versionPage.packageSettingsPage
 
       await portalPage.gotoPackage(testPackage)

--- a/src/tests/portal/03-access-control/3.3.3-owner-group.spec.ts
+++ b/src/tests/portal/03-access-control/3.3.3-owner-group.spec.ts
@@ -35,7 +35,7 @@ test.describe('03.3.3 Access Control. Owner role. (Group)', () => {
       const {
         accessTokensTab,
         accessControlTab,
-        noPermissionPlaceholder
+        noPermissionPlaceholder,
       } = versionPage.packageSettingsPage
 
       await portalPage.gotoGroup(rootGroup)


### PR DESCRIPTION
- Updated Playwright to 1.55.0
  - [1.55.0](https://github.com/microsoft/playwright/releases/tag/v1.55.0)
  - [1.54.0](https://github.com/microsoft/playwright/releases/tag/v1.54.0)
- Updated dev dependencies
- Updated .gitignore, excluded more IDEs
- Fixed Linter errors
- Fixed TypeScript errors

Previous update: #44