### PR TITLE
fix: incorrect security requirement objects in test OAS specifications

### DIFF
--- a/resources/agent/atui_agent_petstore30_base_annotunclas.yaml
+++ b/resources/agent/atui_agent_petstore30_base_annotunclas.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/agent/atui_agent_petstore30_base_annotunclas.yaml
+++ b/resources/agent/atui_agent_petstore30_base_annotunclas.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/agent/atui_agent_petstore30_base_multi_changes.yaml
+++ b/resources/agent/atui_agent_petstore30_base_multi_changes.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/agent/atui_agent_petstore30_base_multi_changes.yaml
+++ b/resources/agent/atui_agent_petstore30_base_multi_changes.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/agent/atui_agent_petstore30_base_non_breaking.yaml
+++ b/resources/agent/atui_agent_petstore30_base_non_breaking.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/agent/atui_agent_petstore30_base_non_breaking.yaml
+++ b/resources/agent/atui_agent_petstore30_base_non_breaking.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/agent/atui_agent_petstore30_changed.yaml
+++ b/resources/agent/atui_agent_petstore30_changed.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/agent/atui_agent_petstore30_changed.yaml
+++ b/resources/agent/atui_agent_petstore30_changed.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/atui_petstore30.yaml
+++ b/resources/portal/atui_petstore30.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/atui_petstore30.yaml
+++ b/resources/portal/atui_petstore30.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/atui_playground.yaml
+++ b/resources/portal/atui_playground.yaml
@@ -56,7 +56,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -118,8 +118,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/atui_playground.yaml
+++ b/resources/portal/atui_playground.yaml
@@ -56,7 +56,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_pet30_base.yaml
+++ b/resources/portal/for-changelog/atui_pet30_base.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_pet30_base.yaml
+++ b/resources/portal/for-changelog/atui_pet30_base.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_pet30_changed.yaml
+++ b/resources/portal/for-changelog/atui_pet30_changed.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_pet30_changed.yaml
+++ b/resources/portal/for-changelog/atui_pet30_changed.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -78,8 +78,8 @@ paths:
                       - name: Admin
                         contact: "admin@petstore.com"
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_petstore30_changelog_annotunclas.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_annotunclas.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_petstore30_changelog_annotunclas.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_annotunclas.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_petstore30_changelog_base.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_base.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_petstore30_changelog_base.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_base.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_petstore30_changelog_changed.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_changed.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_petstore30_changelog_changed.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_changed.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_petstore30_changelog_diff_operations.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_diff_operations.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_petstore30_changelog_diff_operations.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_diff_operations.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/atui_petstore30_changelog_non_breaking.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_non_breaking.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/atui_petstore30_changelog_non_breaking.yaml
+++ b/resources/portal/for-changelog/atui_petstore30_changelog_non_breaking.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-changelog/two-docs/atui_petstore30_changelog_base.yaml
+++ b/resources/portal/for-changelog/two-docs/atui_petstore30_changelog_base.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-changelog/two-docs/atui_petstore30_changelog_base.yaml
+++ b/resources/portal/for-changelog/two-docs/atui_petstore30_changelog_base.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-deprecated/atui_petstore30_deprecated_base.yaml
+++ b/resources/portal/for-deprecated/atui_petstore30_deprecated_base.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-deprecated/atui_petstore30_deprecated_base.yaml
+++ b/resources/portal/for-deprecated/atui_petstore30_deprecated_base.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-deprecated/atui_petstore30_deprecated_changed.yaml
+++ b/resources/portal/for-deprecated/atui_petstore30_deprecated_changed.yaml
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-deprecated/atui_petstore30_deprecated_no_deprecated.yaml
+++ b/resources/portal/for-deprecated/atui_petstore30_deprecated_no_deprecated.yaml
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-global-search/atui_petstore30.yaml
+++ b/resources/portal/for-global-search/atui_petstore30.yaml
@@ -116,8 +116,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-grouping/atui_pet30_base.yaml
+++ b/resources/portal/for-grouping/atui_pet30_base.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-grouping/atui_pet30_base.yaml
+++ b/resources/portal/for-grouping/atui_pet30_base.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-grouping/atui_pet30_changed.yaml
+++ b/resources/portal/for-grouping/atui_pet30_changed.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-grouping/atui_pet30_changed.yaml
+++ b/resources/portal/for-grouping/atui_pet30_changed.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -78,8 +78,8 @@ paths:
                       - name: Admin
                         contact: "admin@petstore.com"
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-grouping/atui_pet30_prop.yaml
+++ b/resources/portal/for-grouping/atui_pet30_prop.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-grouping/atui_pet30_prop.yaml
+++ b/resources/portal/for-grouping/atui_pet30_prop.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     post:
       tags:

--- a/resources/portal/for-grouping/atui_petstore30_prefix_v2.yaml
+++ b/resources/portal/for-grouping/atui_petstore30_prefix_v2.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-grouping/atui_petstore30_prefix_v2.yaml
+++ b/resources/portal/for-grouping/atui_petstore30_prefix_v2.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:

--- a/resources/portal/for-grouping/atui_petstore30_prefix_v2_changed.yaml
+++ b/resources/portal/for-grouping/atui_petstore30_prefix_v2_changed.yaml
@@ -47,7 +47,6 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters: []
       responses:
         200:
           description: "Successful execution"

--- a/resources/portal/for-grouping/atui_petstore30_prefix_v2_changed.yaml
+++ b/resources/portal/for-grouping/atui_petstore30_prefix_v2_changed.yaml
@@ -47,7 +47,7 @@ paths:
       summary: "Get system info"
       description: "Get system info."
       operationId: getInfo
-      parameters:
+      parameters: []
       responses:
         200:
           description: "Successful execution"
@@ -109,8 +109,8 @@ paths:
                   - code
                   - message
       security:
-        - BearerAuth:
-        - api_key:
+        - BearerAuth: []
+        - api_key: []
   /pet:
     put:
       tags:


### PR DESCRIPTION
With incorrect test specification the test `[P-ODPPG-1] Operations details: Checking Playground` started failing (correctly) after this change https://github.com/Netcracker/qubership-apihub-api-processor/pull/45