### PR TITLE
test: align publish/copy tests with previous version status validation

### DIFF
--- a/src/packages/portal/pages/PortalPage/BaseVersionPage/ConfigureVersionTab/PortalPublishVersionDialog.ts
+++ b/src/packages/portal/pages/PortalPage/BaseVersionPage/ConfigureVersionTab/PortalPublishVersionDialog.ts
@@ -5,7 +5,7 @@ import { BasePublishDialog } from '@shared/components/custom'
 
 export class PortalPublishVersionDialog extends BasePublishDialog {
 
-  readonly previousVersionAc = new Autocomplete(this.rootLocator.getByTestId('PreviousReleaseVersionAutocomplete'), 'Previous release version')
+  readonly previousVersionAc = new Autocomplete(this.rootLocator.getByTestId('PreviousReleaseVersionAutocomplete'), 'Previous version')
   readonly publishBtn = new Button(this.rootLocator.getByTestId('PublishButton'), 'Publish')
 
   constructor(protected readonly page: Page) {
@@ -15,7 +15,7 @@ export class PortalPublishVersionDialog extends BasePublishDialog {
   async fillForm(params: PortalPublishParams): Promise<void> {
     await super.fillForm(params)
     if (params.previousVersion) {
-      await report.step('Fill "Previous release version"', async () => {
+      await report.step('Fill "Previous version"', async () => {
         await this.previousVersionAc.click()
         await this.previousVersionAc.getListItem(params.previousVersion).click()
       })

--- a/src/packages/portal/pages/PortalPage/BaseVersionPage/CopyVersionDialog.ts
+++ b/src/packages/portal/pages/PortalPage/BaseVersionPage/CopyVersionDialog.ts
@@ -7,7 +7,7 @@ export class CopyVersionDialog extends BasePublishDialog {
 
   readonly workspaceAc = new Autocomplete(this.rootLocator.getByTestId('WorkspaceAutocomplete'), 'Workspace')
   readonly packageAc = new Autocomplete(this.rootLocator.getByTestId('PackageAutocomplete'), 'Package')
-  readonly previousVersionAc = new Autocomplete(this.rootLocator.getByTestId('PreviousReleaseVersionAutocomplete'), 'Previous release version')
+  readonly previousVersionAc = new Autocomplete(this.rootLocator.getByTestId('PreviousReleaseVersionAutocomplete'), 'Previous version')
   readonly copyBtn = new Button(this.rootLocator.getByTestId('CopyButton'), 'Copy')
 
   constructor(protected readonly page: Page) {
@@ -29,7 +29,7 @@ export class CopyVersionDialog extends BasePublishDialog {
     }
     await super.fillForm(params)
     if (params.previousVersion) {
-      await report.step('Set "Previous release version"', async () => {
+      await report.step('Set "Previous version"', async () => {
         await this.previousVersionAc.click()
         await this.previousVersionAc.getListItem(params.previousVersion).click()
       })

--- a/src/packages/shared/entities/list-items.ts
+++ b/src/packages/shared/entities/list-items.ts
@@ -1,1 +1,2 @@
 export const NO_PREV_RELEASE_VERSION = 'No previous release version'
+export const NO_PREV_VERSION = 'No previous version'

--- a/src/tests/portal/04-entity-actions/4.3.2-package-editing-publishing.spec.ts
+++ b/src/tests/portal/04-entity-actions/4.3.2-package-editing-publishing.spec.ts
@@ -391,7 +391,7 @@ test.describe('4.3.2 Package publishing via Portal', () => {
         await configureVersionTab.publishVersionDialog.fillForm({
           version: '2000.3',
           status: 'release',
-          previousVersion: testVersion.version,
+          previousVersion: `${testVersion.version} ${testVersion.status}`,
         })
         await configureVersionTab.publishVersionDialog.publishBtn.click()
 

--- a/src/tests/portal/04-entity-actions/4.4.2-dashboard-editing-publishing.spec.ts
+++ b/src/tests/portal/04-entity-actions/4.4.2-dashboard-editing-publishing.spec.ts
@@ -166,7 +166,7 @@ test.describe('4.4.2 Dashboard editing/publishing', () => {
       await publishVersionDialog.fillForm({
         version: 'with-prev-version',
         status: 'draft',
-        previousVersion: V_P_DSH_RELEASE_N.version,
+        previousVersion: `${V_P_DSH_RELEASE_N.version} ${V_P_DSH_RELEASE_N.status}`,
       })
       await publishVersionDialog.publishBtn.click()
 

--- a/src/tests/portal/14-copying/14.1-copying-package-version.spec.ts
+++ b/src/tests/portal/14-copying/14.1-copying-package-version.spec.ts
@@ -255,7 +255,7 @@ test.describe('14.1 Copying Package Version', () => {
           version: targetVersion,
           status: RELEASE_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: V_P_PKG_COPYING_RELEASE_N.version,
+          previousVersion: `${V_P_PKG_COPYING_RELEASE_N.version} ${V_P_PKG_COPYING_RELEASE_N.status}`,
         })
         await copyVersionDialog.copyBtn.click()
 

--- a/src/tests/portal/14-copying/14.1-copying-package-version.spec.ts
+++ b/src/tests/portal/14-copying/14.1-copying-package-version.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@fixtures'
 import { PortalPage } from '@portal/pages/PortalPage'
 import { expect } from '@services/expect-decorator'
-import { DRAFT_VERSION_STATUS, NO_PREV_RELEASE_VERSION, RELEASE_VERSION_STATUS } from '@shared/entities'
+import { DRAFT_VERSION_STATUS, NO_PREV_RELEASE_VERSION, NO_PREV_VERSION, RELEASE_VERSION_STATUS } from '@shared/entities'
 import { P_PK_CP_EMPTY, P_PK_CP_PATTERN, P_PK_CP_RELEASE, P_WS_MAIN_R, RV_PATTERN_NEW, V_P_PKG_COPYING_RELEASE_N, V_P_PKG_COPYING_SOURCE_R, VERSION_COPIED_MSG } from '@test-data/portal'
 import { PUBLISH_TIMEOUT, TICKET_BASE_URL } from '@test-setup'
 import { SYSADMIN } from '@test-data'
@@ -103,7 +103,7 @@ test.describe('14.1 Copying Package Version', () => {
           version: '2000.2',
           status: DRAFT_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: NO_PREV_RELEASE_VERSION,
+          previousVersion: NO_PREV_VERSION,
         })
 
         await expect(copyVersionDialog.workspaceAc).toHaveValue(targetWorkspace.name)
@@ -158,7 +158,7 @@ test.describe('14.1 Copying Package Version', () => {
           version: targetVersion,
           status: DRAFT_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: NO_PREV_RELEASE_VERSION,
+          previousVersion: NO_PREV_VERSION,
         })
         await copyVersionDialog.copyBtn.click()
 
@@ -247,7 +247,7 @@ test.describe('14.1 Copying Package Version', () => {
         })
 
         await expect(copyVersionDialog.packageAc).toHaveValue(targetPackage.name)
-        await expect(copyVersionDialog.previousVersionAc).toHaveValue(NO_PREV_RELEASE_VERSION)
+        await expect(copyVersionDialog.previousVersionAc).toHaveValue(NO_PREV_VERSION)
       })
 
       await test.step('Set target Version Info and copy Version', async () => {

--- a/src/tests/portal/14-copying/14.2-copying-dashboard-version.spec.ts
+++ b/src/tests/portal/14-copying/14.2-copying-dashboard-version.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@fixtures'
 import { PortalPage } from '@portal/pages/PortalPage'
 import { expect } from '@services/expect-decorator'
-import { DRAFT_VERSION_STATUS, NO_PREV_RELEASE_VERSION, RELEASE_VERSION_STATUS } from '@shared/entities'
+import { DRAFT_VERSION_STATUS, NO_PREV_RELEASE_VERSION, NO_PREV_VERSION, RELEASE_VERSION_STATUS } from '@shared/entities'
 import {
   P_DSH_CP_EMPTY,
   P_DSH_CP_PATTERN,
@@ -114,7 +114,7 @@ test.describe('14.2 Copying Dashboard Version', () => {
           version: '2000.2',
           status: DRAFT_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: NO_PREV_RELEASE_VERSION,
+          previousVersion: NO_PREV_VERSION,
         })
 
         await expect(copyVersionDialog.workspaceAc).toHaveValue(targetWorkspace.name)
@@ -169,7 +169,7 @@ test.describe('14.2 Copying Dashboard Version', () => {
           version: targetVersion,
           status: DRAFT_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: NO_PREV_RELEASE_VERSION,
+          previousVersion: NO_PREV_VERSION,
         })
         await copyVersionDialog.copyBtn.click()
 
@@ -274,7 +274,7 @@ test.describe('14.2 Copying Dashboard Version', () => {
         })
 
         await expect(copyVersionDialog.packageAc).toHaveValue(targetDashboard.name)
-        await expect(copyVersionDialog.previousVersionAc).toHaveValue(NO_PREV_RELEASE_VERSION)
+        await expect(copyVersionDialog.previousVersionAc).toHaveValue(NO_PREV_VERSION)
       })
 
       await test.step('Set target Version Info and copy Version', async () => {

--- a/src/tests/portal/14-copying/14.2-copying-dashboard-version.spec.ts
+++ b/src/tests/portal/14-copying/14.2-copying-dashboard-version.spec.ts
@@ -282,7 +282,7 @@ test.describe('14.2 Copying Dashboard Version', () => {
           version: targetVersion,
           status: RELEASE_VERSION_STATUS,
           labels: ['label-1', 'label-2'],
-          previousVersion: V_P_DSH_COPYING_RELEASE_N.version,
+          previousVersion: `${V_P_DSH_COPYING_RELEASE_N.version} ${V_P_DSH_COPYING_RELEASE_N.status}`,
         })
         await copyVersionDialog.copyBtn.click()
 


### PR DESCRIPTION
## Summary

Updates Portal UI tests and page objects to match status-aware previous-version behavior introduced in
[Netcracker/qubership-apihub-ui#302](https://github.com/Netcracker/qubership-apihub-ui/pull/302).

Closes [Netcracker/qubership-apihub#709](https://github.com/Netcracker/qubership-apihub/issues/709).

Related changes:
- UI: [Netcracker/qubership-apihub-ui#302](https://github.com/Netcracker/qubership-apihub-ui/pull/302)
- VS Code extension: [Netcracker/qubership-apihub-vscode#55](https://github.com/Netcracker/qubership-apihub-vscode/pull/55)

The publish and copy dialogs now use status-dependent labels and show version status in previous-version
dropdown options. These updates keep existing E2E tests passing against the new UI.

## Changes

### Page objects
- **PortalPublishVersionDialog** and **CopyVersionDialog:** update previous-version autocomplete label
  from “Previous release version” to “Previous version” to match draft-status wording in the updated UI.

### Test data
- Add `NO_PREV_VERSION` (`No previous version`) alongside existing `NO_PREV_RELEASE_VERSION`.

### Spec updates
- **4.3.2 Package publishing:** select previous version using `version status` format to match options
  that now include status chips.
- **4.4.2 Dashboard publishing:** same update for draft publish with a previous version.
- **14.1 Copying package version:** use `NO_PREV_VERSION` for draft copies; use `version status` when
  selecting a release previous version.
- **14.2 Copying dashboard version:** same adjustments as package copying tests.

## Test plan

- [ ] `4.3.2-package-editing-publishing.spec.ts` — package publish with previous version passes.
- [ ] `4.4.2-dashboard-editing-publishing.spec.ts` — dashboard publish with previous version passes.
- [ ] `14.1-copying-package-version.spec.ts` — draft and release copy flows pass, including
  “No previous version” assertions for draft.
- [ ] `14.2-copying-dashboard-version.spec.ts` — same for dashboard copy flows.