### PR TITLE
test: cover dashboard API changes description bug

### DIFF
--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -560,14 +560,17 @@ Test data is categorized into two types based on reusability and lifecycle:
 - Non-reusable data (`_N`) is automatically cleaned up after each test run via `apihub-teardown.ts`
 - Reusable data (`_R`) persists unless explicitly cleared with `CLEAR_TD === 'all'`
 - Ensure all non-reusable test data includes `process.env.TEST_ID_N!` in its name/identifier for proper cleanup identification
+- **Do not** clear packages/versions from suite `afterAll` with `deletePackage` / ad-hoc REST deletes. Cleanup is global: `apihub-teardown.ts` calls `apihubTDM.deleteTestEntities(testId)`, which uses `DELETE /api/internal/clear/{testId}` (`rClearTestData`)
+- For `_N` entities, teardown uses `TEST_ID_N`; for `_R`, only when `CLEAR_TD === 'all'`, teardown uses `TEST_ID_R`
 
 ### Placement & Hooks
 
 - Start by defining data inside the spec (or its `tests/<feature>` folder). Only extract it to `src/test-data/**` when multiple suites genuinely need it.
 - Use Playwright lifecycle hooks to control data scope:
   - `beforeEach`/`afterEach` → per-test setup/cleanup
-  - `beforeAll`/`afterAll` → suite-level fixtures
+  - `beforeAll`/`afterAll` → suite-level fixtures (create data here; prefer global teardown for deletion)
 - When using API-based managers, wrap the calls in these hooks so that failures are easier to trace and cleanup always runs, even if the test fails early.
+- `createPackage` is already idempotent. Prefer `apihubTDM.publishVersionIfMissing(...)` only for **reusable** (`_R`) versions that must stay stable across runs/retries. For **non-reusable** (`_N`) data that must be fresh on each retry, do **not** reuse an existing version — give it a unique name (for example include `test.info().retry`) and call `publishVersion`.
 
 ### Hook Timeouts
 
@@ -581,7 +584,8 @@ test.beforeAll(async ({ apihubTDM }) => {
   test.setTimeout(HOOK_PUBLISH_TIMEOUT)
 
   await apihubTDM.createPackage([...])
-  await apihubTDM.publishVersion(V_OAS30_N)
+  // Reusable (_R): skip publish when the version already exists
+  await apihubTDM.publishVersionIfMissing(V_OAS30_R)
 })
 ```
 

--- a/src/services/rest/requests.versions.ts
+++ b/src/services/rest/requests.versions.ts
@@ -6,7 +6,7 @@ export async function rGetPackageVersion(rc: APIRequestContext, params: {
   packageId: string
   version: string
 }): Promise<APIResponse> {
-  return await rc.get(`/api/v2/packages/${params.packageId}/versions/${params.version}`)
+  return await rc.get(`/api/v3/packages/${params.packageId}/versions/${params.version}`)
 }
 
 export async function rUpdatePackageVersion(rc: APIRequestContext, params: {

--- a/src/services/test-data-manager/tdm.apihub.ts
+++ b/src/services/test-data-manager/tdm.apihub.ts
@@ -16,6 +16,7 @@ import {
   rFavorPackage,
   rGetPackageById,
   rGetPackagesList,
+  rGetPackageVersion,
   rGetPublishStatus,
   rGetSysadminsList,
   rGetUsersList,
@@ -250,6 +251,17 @@ export class ApihubTestDataManager {
     }, { box: true })
   }
 
+  /**
+   * Publishes a version only when it is not already present.
+   * Use for idempotent suite setup / retries.
+   */
+  async publishVersionIfMissing(params: TdmPublishVersion): Promise<void> {
+    if (await this.isVersionExist({ packageId: params.pkg.packageId, version: params.version })) {
+      return
+    }
+    await this.publishVersion(params)
+  }
+
   async updatePackageVersion(params: {
     pkg: {
       packageId: string
@@ -467,5 +479,13 @@ export class ApihubTestDataManager {
     const response = await this.getPackageById(packageId)
     const jsonBody = await response.json()
     return response.status() === 200 && jsonBody.packageId === packageId
+  }
+
+  private async isVersionExist(params: { packageId: string; version: string }): Promise<boolean> {
+    const response = await this.rest.send(rGetPackageVersion, [200, 404], params)
+    if (response.status() !== 200 && response.status() !== 404) {
+      throw Error(await getRestFailMsg(`Getting "${params.packageId}/${params.version}" version`, response))
+    }
+    return response.status() === 200
   }
 }

--- a/src/test-setup/process.ts
+++ b/src/test-setup/process.ts
@@ -15,3 +15,6 @@ export const CREATE_TD = process.env.CREATE_TD as 'all' | 'skip' | undefined
  * **skip** - skip test data clearing
  */
 export const CLEAR_TD = process.env.CLEAR_TD as 'all' | 'skip' | undefined
+
+/** Skip reason when `CREATE_TD === 'skip'`. */
+export const MSG_CREATE_TD_SKIPPED = 'Test Data creation is skipped'

--- a/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.spec.ts
+++ b/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.spec.ts
@@ -1,0 +1,59 @@
+import { registerVersionFiles, test } from '@fixtures'
+import { VERSION_CHANGES_TAB_REST } from '@portal/entities'
+import { PortalPage } from '@portal/pages/PortalPage'
+import { expect } from '@services/expect-decorator'
+import {
+  MSG_CHANGES_DESC,
+  OP_CHANGES_DESC,
+  setupChangesDescTestData,
+  V_CHANGES_DESC_DSH_2_R,
+  V_CHANGES_DESC_PKG_1_R,
+  V_CHANGES_DESC_PKG_2_R,
+  V_CHANGES_DESC_PKG_3_R,
+} from './dsh-changes-description.test-data'
+
+/**
+ * Dashboard API Changes: human-readable change descriptions must expand the same way as for packages
+ * when comparing non-linear package versions via a dashboard (https://github.com/Netcracker/qubership-apihub/issues/706).
+ */
+
+test.describe('Dashboard API Changes description', () => {
+  test.beforeAll(async ({ apihubTDM }) => {
+    await setupChangesDescTestData(apihubTDM)
+  })
+
+  test('P-BUG-706 Expand operation change description on dashboard API Changes tab', async ({ sysadminPage: page, usedResources }) => {
+    const portalPage = new PortalPage(page)
+    const { versionDashboardPage: versionPage } = portalPage
+    const { apiChangesTab } = versionPage
+
+    registerVersionFiles(usedResources, [
+      V_CHANGES_DESC_PKG_1_R,
+      V_CHANGES_DESC_PKG_2_R,
+      V_CHANGES_DESC_PKG_3_R,
+    ])
+
+    await portalPage.gotoVersion(V_CHANGES_DESC_DSH_2_R, VERSION_CHANGES_TAB_REST)
+
+    const operationRow = apiChangesTab.table.getOperationRow(OP_CHANGES_DESC)
+
+    await test.step('Verify changed operation is listed on API Changes tab', async () => {
+      await expect(operationRow).toBeVisible()
+    })
+
+    await operationRow.expandBtn.click()
+
+    await test.step('Verify operation row is expanded', async () => {
+      await expect(operationRow.collapseBtn).toBeVisible()
+    })
+
+    await test.step('Verify human-readable change description is displayed', async () => {
+      const changeDescriptionCell = apiChangesTab.table.getChangeDescriptionCell(MSG_CHANGES_DESC)
+
+      await expect(changeDescriptionCell).toBeVisible()
+      await expect(changeDescriptionCell.mainLocator.getByText(MSG_CHANGES_DESC, { exact: true })).toHaveText(
+        MSG_CHANGES_DESC,
+      )
+    })
+  })
+})

--- a/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.spec.ts
+++ b/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.spec.ts
@@ -48,12 +48,7 @@ test.describe('Dashboard API Changes description', () => {
     })
 
     await test.step('Verify human-readable change description is displayed', async () => {
-      const changeDescriptionCell = apiChangesTab.table.getChangeDescriptionCell(MSG_CHANGES_DESC)
-
-      await expect(changeDescriptionCell).toBeVisible()
-      await expect(changeDescriptionCell.mainLocator.getByText(MSG_CHANGES_DESC, { exact: true })).toHaveText(
-        MSG_CHANGES_DESC,
-      )
+      await expect(apiChangesTab.table.getChangeDescriptionCell(MSG_CHANGES_DESC)).toBeVisible()
     })
   })
 })

--- a/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.test-data.ts
+++ b/src/tests/portal/99-bugs/706-dsh-changes-description/dsh-changes-description.test-data.ts
@@ -1,0 +1,121 @@
+import { test } from '@fixtures'
+import type { ApihubTestDataManager } from '@services/test-data-manager'
+import {
+  CREATE_LIST_OF_USERS_V1_UPDATED,
+  FILE_P_PETSTORE30_CHANGELOG_BASE,
+  FILE_P_PETSTORE30_CHANGELOG_CHANGED,
+  IMM_GR,
+} from '@test-data/portal'
+import { Dashboard, Group, Package, type Version } from '@test-data/props'
+import { HOOK_PUBLISH_TIMEOUT } from '@test-setup'
+
+/**
+ * Group under Reusable (IMM_GR) for bug-regression packages/dashboards.
+ */
+export const G_BUGS_IMM = new Group({
+  name: 'Bugs',
+  alias: 'GBUGSIMM',
+  parent: IMM_GR,
+  description: 'Reusable group for bug-regression test data',
+})
+
+/**
+ * Suite subgroup.
+ */
+export const G_CHANGES_DESC_R = new Group({
+  name: '706-Dsh-Changes-Description',
+  alias: 'GCHDESC',
+  parent: G_BUGS_IMM,
+})
+
+/**
+ * Package with a three-version release chain.
+ *
+ * v1 (base) -> v2 (changed) -> v3 (same as v2, no delta).
+ */
+export const PKG_CHANGES_DESC_R = new Package({
+  name: 'Package',
+  alias: 'PKCHDESC',
+  parent: G_CHANGES_DESC_R,
+}, { kindPrefix: true })
+
+/**
+ * Dashboard that compares package v1 vs v3 via two release versions.
+ */
+export const DSH_CHANGES_DESC_R = new Dashboard({
+  name: 'Dashboard',
+  alias: 'DSHCHDESC',
+  parent: G_CHANGES_DESC_R,
+}, { kindPrefix: true })
+
+export const FILE_CHANGES_DESC_BASE = FILE_P_PETSTORE30_CHANGELOG_BASE
+export const FILE_CHANGES_DESC_CHANGED = FILE_P_PETSTORE30_CHANGELOG_CHANGED
+
+/** Operation whose change details must be expandable on the dashboard API Changes tab. */
+export const OP_CHANGES_DESC = CREATE_LIST_OF_USERS_V1_UPDATED
+
+/** Exact human-readable change description asserted in the UI. */
+export const MSG_CHANGES_DESC = OP_CHANGES_DESC.changes!.breaking!.description
+
+export const V_CHANGES_DESC_PKG_1_R: Version = {
+  pkg: PKG_CHANGES_DESC_R,
+  version: '2000.1',
+  status: 'release',
+  files: [{ file: FILE_CHANGES_DESC_BASE }],
+}
+
+export const V_CHANGES_DESC_PKG_2_R: Version = {
+  pkg: PKG_CHANGES_DESC_R,
+  version: '2000.2',
+  status: 'release',
+  previousVersion: V_CHANGES_DESC_PKG_1_R.version,
+  files: [{ file: FILE_CHANGES_DESC_CHANGED, fileId: FILE_CHANGES_DESC_BASE.name }],
+}
+
+export const V_CHANGES_DESC_PKG_3_R: Version = {
+  pkg: PKG_CHANGES_DESC_R,
+  version: '2000.3',
+  status: 'release',
+  previousVersion: V_CHANGES_DESC_PKG_2_R.version,
+  files: [{ file: FILE_CHANGES_DESC_CHANGED, fileId: FILE_CHANGES_DESC_BASE.name }],
+}
+
+export const V_CHANGES_DESC_DSH_1_R: Version = {
+  pkg: DSH_CHANGES_DESC_R,
+  version: '2000.1',
+  status: 'release',
+  refs: [
+    { refId: PKG_CHANGES_DESC_R.packageId, version: V_CHANGES_DESC_PKG_1_R.version },
+  ],
+}
+
+export const V_CHANGES_DESC_DSH_2_R: Version = {
+  pkg: DSH_CHANGES_DESC_R,
+  version: '2000.2',
+  status: 'release',
+  previousVersion: V_CHANGES_DESC_DSH_1_R.version,
+  refs: [
+    { refId: PKG_CHANGES_DESC_R.packageId, version: V_CHANGES_DESC_PKG_3_R.version },
+  ],
+}
+
+/**
+ * Creates reusable entities when missing.
+ * Idempotent via createPackage / publishVersionIfMissing.
+ */
+export const setupChangesDescTestData = async (apihubTDM: ApihubTestDataManager): Promise<void> => {
+  test.setTimeout(HOOK_PUBLISH_TIMEOUT)
+
+  await apihubTDM.createPackage([
+    G_BUGS_IMM,
+    G_CHANGES_DESC_R,
+    PKG_CHANGES_DESC_R,
+    DSH_CHANGES_DESC_R,
+  ])
+
+  await apihubTDM.publishVersionIfMissing(V_CHANGES_DESC_PKG_1_R)
+  await apihubTDM.publishVersionIfMissing(V_CHANGES_DESC_PKG_2_R)
+  await apihubTDM.publishVersionIfMissing(V_CHANGES_DESC_PKG_3_R)
+  await apihubTDM.publishVersionIfMissing(V_CHANGES_DESC_DSH_1_R)
+  await apihubTDM.publishVersionIfMissing(V_CHANGES_DESC_DSH_2_R)
+}

--- a/src/tests/portal/setup.ts
+++ b/src/tests/portal/setup.ts
@@ -355,7 +355,7 @@ import {
   WSP_P_UAC_GENERAL_N,
 } from '@test-data/portal'
 import { isReusableTestDataExist } from '@test-data/utils'
-import { CREATE_TD } from '@test-setup'
+import { CREATE_TD, MSG_CREATE_TD_SKIPPED } from '@test-setup'
 
 test.describe.configure({ mode: 'serial' })
 
@@ -369,7 +369,7 @@ test.describe('Users', async () => {
 })
 
 test.describe('Reusable Test Data creation', async () => {
-  test.skip(CREATE_TD === 'skip', 'Test Data creation is skipped')
+  test.skip(CREATE_TD === 'skip', MSG_CREATE_TD_SKIPPED)
 
   let isReusableTdExist!: boolean
 
@@ -693,7 +693,7 @@ test.describe('Reusable Test Data creation', async () => {
 })
 
 test.describe('Non-Reusable Test Data creation', async () => {
-  test.skip(CREATE_TD === 'skip', 'Test Data creation is skipped')
+  test.skip(CREATE_TD === 'skip', MSG_CREATE_TD_SKIPPED)
 
   test.describe('General', async () => {
     test('Test Entities creation', async ({ apihubTDM: tdm }) => {


### PR DESCRIPTION
- Add Playwright coverage for dashboard API Changes human-readable descriptions when comparing non-linear package versions (https://github.com/Netcracker/qubership-apihub/issues/706).
- Fix `rGetPackageVersion` to use `/api/v3`, add `publishVersionIfMissing` for stable `_R` setup, and document global clear-test-data cleanup vs `_N`/`_R` publish rules.